### PR TITLE
Initial dockerfile and docker compose. Tested to _startup_

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,31 @@
+# syntax=docker/dockerfile:1.3-labs
 FROM docker.io/python:3.10-slim-bookworm
+MAINTAINER @penguincoder:hive.beehaw.org
+LABEL org.opencontainers.image.source https://github.com/db0/pictrs-safety
+
+ARG DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /app
-COPY requirements.txt requirements.txt
 
+RUN <<EOF
+    set -eu
+    apt-get -qq update
+    apt-get -qq upgrade
+    apt-get -qq install --no-install-recommends apt-utils dumb-init dnsutils > /dev/null
+    apt-get -qq autoremove
+    apt-get clean
+    ln -s /usr/lib/libssl.so /usr/lib/libssl.so.1.1
+    rm -rf /var/lib/apt/lists/*
+    groupadd -r -g 991 pictrs
+    useradd -r -u 991 -g 991 -s /sbin/false -M pictrs
+    chown -R 991:991 /app
+EOF
+
+COPY --chown=991:991 . .
 ENV PYTHONPATH='/app'
 RUN pip install --no-cache-dir -r requirements.txt
-COPY . .
-ENTRYPOINT [ "python3.10" ]
+USER pictrs
+ENTRYPOINT [ "/usr/bin/dumb-init", "--" ]
+STOPSIGNAL SIGINT
 EXPOSE 14051
 CMD ["python", "api_server.py", "-vvi"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+
+services:
+  pictrs-safety:
+    image: ghcr.io/db0/pictrs-safety:latest
+    hostname: "pictrs-safety"
+    
+    expose:
+      - '14051'
+    
+    user: 991:991
+
+    environment:
+      - USE_SQLITE=0
+      - FEDIVERSE_SAFETY_WORKER_AUTH=${FEDIVERSE_SAFETY_WORKER_AUTH}
+      - FEDIVERSE_SAFETY_IMGDIR=${FEDIVERSE_SAFETY_IMGDIR}
+      - POSTGRES_URI=${POSTGRES_URI}
+      - KNOWN_PICTRS_IPS=${KNOWN_PICTRS_IPS}
+    
+    restart: unless-stopped


### PR DESCRIPTION
Didn't test to run in actual production yet. 

Follow some instructions on setting up the [GH container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) for this repo. Then, build from docker file and once completed do:

```
docker image tag custom/pictrs-safety ghcr.io/db0/pictrs-safety:v0.1
docker image push ghcr.io/db0/pictrs-safety:v0.1
```

Users should copy/move the `.env_template` to `.env` and set the variables there. Then a `docker compose up` in the same directory will read from the .env to populate the docker-compose.yml